### PR TITLE
pom.xml: move test dependencies to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,13 @@ http://central.sonatype.org/pages/apache-maven.html
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Leaving `junit` and `hamcrest` in the default `compile` scope meant that they were included as transient dependencies of any module that depended upon this module.